### PR TITLE
Improve passing user data via cli

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -1,16 +1,46 @@
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+    fs::File,
+    io::{self, BufReader},
+};
+
 use chrono::{DateTime, NaiveDateTime, ParseResult, Utc};
 use clap::Parser;
 
-// todo replace "author" with user and load it using some user.json file path as argument
+use crate::model::user::User;
+
+#[derive(Debug)]
+struct CliError {
+    message: String,
+}
+
+impl CliError {
+    pub fn new(msg: &str) -> Self {
+        Self {
+            message: String::from(msg),
+        }
+    }
+}
+
+impl Display for CliError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl Error for CliError {}
+
+// todo re-run code formatter in rustrover because vscode is trippin
 #[derive(Debug, Parser)]
 #[command(version, author, about, long_about = None)]
 pub(crate) struct Cli {
     /// Name of the generated project
     #[arg(short, long)]
     pub(crate) name: String,
-    /// Jira username or email to appear as the project author
-    #[arg(short, long)]
-    pub(crate) author: String,
+    /// Fully qualified name (with path) of json file with user data
+    #[arg(short, long, value_name = "PATH", value_parser = parse_user)]
+    pub(crate) author: User,
     /// Start date of the project (dd-mm-YYYY)
     #[arg(short, long, value_name = "DATE", value_parser = parse_date)]
     pub(crate) start: DateTime<Utc>,
@@ -22,9 +52,18 @@ pub(crate) struct Cli {
     pub(crate) issue_amount: i32,
 }
 
-fn parse_date(arg: &str) -> ParseResult<DateTime<Utc>> {
+fn parse_user(arg: &str) -> Result<User, CliError> {
+    let file = File::open(arg).map_err(|e| CliError::new(&e.to_string()))?;
+    let reader = BufReader::new(file);
+    let usr: User = serde_json::from_reader(reader).map_err(|e| CliError::new(&e.to_string()))?;
+
+    Ok(usr)
+}
+
+fn parse_date(arg: &str) -> Result<DateTime<Utc>, CliError> {
     let s = &format!("{arg} 21:37:00");
-    let naive = NaiveDateTime::parse_from_str(s, "%d-%m-%Y %H:%M:%S")?;
+    let naive = NaiveDateTime::parse_from_str(s, "%d-%m-%Y %H:%M:%S")
+        .map_err(|e| CliError::new(&e.to_string()))?;
     let utc = DateTime::<Utc>::from_naive_utc_and_offset(naive, Utc);
 
     Ok(utc)

--- a/src/gen/history_entry_gen.rs
+++ b/src/gen/history_entry_gen.rs
@@ -3,8 +3,8 @@ use rand::rngs::ThreadRng;
 use rand::thread_rng;
 
 use crate::cli::cli::Cli;
-use crate::gen::{AgileMasterError, Generator};
 use crate::gen::date_gen::DateGenerator;
+use crate::gen::{AgileMasterError, Generator};
 use crate::model::history_entry::HistoryEntry;
 use crate::model::history_item::HistoryItem;
 
@@ -18,10 +18,15 @@ pub(crate) struct HistoryEntryGenerator<'l> {
 impl<'l> HistoryEntryGenerator<'l> {
     pub fn new(cli_args: &'l Cli, statuses: &'l Vec<String>) -> Result<Self, AgileMasterError> {
         let rng = thread_rng();
-        let author = &cli_args.author;
+        let author = &cli_args.author.name;
         let date_gen = DateGenerator::new(cli_args).map_err(|_| AgileMasterError)?;
         dbg!(&date_gen);
-        Ok(Self { rng, author, date_gen, statuses })
+        Ok(Self {
+            rng,
+            author,
+            date_gen,
+            statuses,
+        })
     }
 
     fn rand_status(&mut self) -> &String {

--- a/src/gen/issue_gen.rs
+++ b/src/gen/issue_gen.rs
@@ -1,9 +1,9 @@
 use rand::rngs::ThreadRng;
 
 use crate::cli::cli::Cli;
-use crate::gen::{AgileMasterError, Generator};
 use crate::gen::date_gen::DateGenerator;
 use crate::gen::history_entry_gen::HistoryEntryGenerator;
+use crate::gen::{AgileMasterError, Generator};
 use crate::model::issue::Issue;
 
 pub(crate) struct IssueGenerator<'l> {
@@ -24,8 +24,15 @@ impl<'l> IssueGenerator<'l> {
         let counter = 1;
         let rng = rand::thread_rng();
         let date_gen = DateGenerator::new(cli_args).map_err(|_| AgileMasterError)?;
-        let reporter = cli_args.author.clone();
-        Ok(Self { counter, rng, date_gen, reporter, history_entry_gen, statuses })
+        let reporter = cli_args.author.name.clone();
+        Ok(Self {
+            counter,
+            rng,
+            date_gen,
+            reporter,
+            history_entry_gen,
+            statuses,
+        })
     }
 }
 

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -3,8 +3,6 @@ use std::fs::File;
 use std::io;
 use std::io::Write;
 
-use serde::de::Error;
-
 use crate::cli::cli::Cli;
 use crate::gen::export_gen::ExportGenerator;
 use crate::gen::history_entry_gen::HistoryEntryGenerator;
@@ -12,10 +10,10 @@ use crate::gen::issue_gen::IssueGenerator;
 use crate::gen::project_gen::ProjectGenerator;
 use crate::model::user::User;
 
-pub(crate) mod issue_gen;
 pub(crate) mod date_gen;
 pub(crate) mod export_gen;
 pub(crate) mod history_entry_gen;
+pub(crate) mod issue_gen;
 pub(crate) mod project_gen;
 
 pub(crate) trait Generator<T> {
@@ -42,14 +40,7 @@ pub fn generate_json(project_name: &String, args: &Cli) -> Result<(), AgileMaste
     let mut hist_entry_gen = HistoryEntryGenerator::new(args, &statuses)?;
     let mut issue_gen = IssueGenerator::new(args, &mut hist_entry_gen, &statuses)?;
     let mut proj_gen = ProjectGenerator::new(args, &mut issue_gen);
-    let usr = User::new(
-        String::from("jakublaba"),
-        vec![],
-        true,
-        String::from("jakub.maciej.laba@gmail.com"),
-        String::from("Jakub Łaba"),
-    );
-    let mut export_gen = ExportGenerator::new(usr, &mut proj_gen);
+    let mut export_gen = ExportGenerator::new(args.author.clone(), &mut proj_gen);
 
     let export = export_gen.generate();
     let json = serde_json::to_string(&export).map_err(|_| AgileMasterError)?;

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -1,8 +1,8 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct User {
-    name: String,
+    pub(crate) name: String,
     groups: Vec<String>,
     active: bool,
     email: String,
@@ -18,6 +18,12 @@ impl User {
         email: String,
         full_name: String,
     ) -> Self {
-        Self { name, groups, active, email, full_name }
+        Self {
+            name,
+            groups,
+            active,
+            email,
+            full_name,
+        }
     }
 }


### PR DESCRIPTION
Now the `--author` flag requires fully qualified file name to a `.json` of the following structure:
```json
{
  "name": [string, short username],
  "groups": [array, groups the user is in],
  "active": [boolean, whether account is active or not],
  "email": [string, email address of the user],
  "fullname": [string, full name of the user]
}
```